### PR TITLE
Foreign Key Constraints

### DIFF
--- a/DataAccessLogic/src/main/java/Database/ContainsRepository.java
+++ b/DataAccessLogic/src/main/java/Database/ContainsRepository.java
@@ -6,29 +6,29 @@ import java.sql.SQLException;
 import java.util.List;
 
 public class ContainsRepository {
+
     public void batchInsertContains(int documentId, List<Integer> termIds) {
         String sqlInsert = "INSERT INTO contain_tbl(terms_id, documents_id, position_index)"
                 + "VALUES(?, ?, ?)";
 
         try (Connection connection = Database.getConnection();
-             PreparedStatement preparedStatement = connection.prepareStatement(sqlInsert)) {
+             PreparedStatement insertStatement = connection.prepareStatement(sqlInsert)
+        ) {
             connection.setAutoCommit(false);
-
             int positionId = 1;
 
             int i = 0;
             for (int termId : termIds) {
-                preparedStatement.setInt(1, termId);
-                preparedStatement.setInt(2, documentId);
-                preparedStatement.setInt(3, positionId);
-                preparedStatement.addBatch();
+                insertStatement.setInt(1, termId);
+                insertStatement.setInt(2, documentId);
+                insertStatement.setInt(3, positionId);
+                insertStatement.addBatch();
                 positionId++;
                 i++;
                 if (i % 1000 == 0 || i == termIds.size()) {
-                    preparedStatement.executeBatch();
+                    insertStatement.executeBatch();
                 }
             }
-
             connection.commit();
         } catch (SQLException ex) {
             ex.printStackTrace();

--- a/DataAccessLogic/src/main/java/Database/DocumentsRepository.java
+++ b/DataAccessLogic/src/main/java/Database/DocumentsRepository.java
@@ -1,7 +1,10 @@
 package Database;
+
 import DomainModels.Document;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
 
 public class DocumentsRepository {
     public void insertDocument(Document document){

--- a/DataAccessLogic/src/main/java/Database/ForeignKeyConstraints.java
+++ b/DataAccessLogic/src/main/java/Database/ForeignKeyConstraints.java
@@ -1,0 +1,40 @@
+package Database;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+
+/**
+ * Created by HassanMahmud on 14/03/2016.
+ */
+public class ForeignKeyConstraints {
+
+    private static final String ADD_FK_CONSTRAINT
+            = "ALTER TABLE contain_tbl "
+            + "ADD CONSTRAINT contain_term_fk1 "
+            + "FOREIGN KEY(terms_id) "
+            + "REFERENCES terms_tbl(terms_id) "
+            + "ON DELETE CASCADE";
+
+    private static final String DROP_FK_CONSTRAINT
+            = "ALTER TABLE contain_tbl DROP FOREIGN KEY contain_term_fk1";
+
+
+    public void createTermIDFKConstraint() {
+        executeStatement(ADD_FK_CONSTRAINT);
+    }
+
+    public void dropTermIDFKConstraint() {
+        executeStatement(DROP_FK_CONSTRAINT);
+    }
+
+    private void executeStatement(String SQL) {
+        try (Connection connection = Database.getConnection();
+             Statement statment = connection.createStatement()
+        ) {
+            statment.executeUpdate(SQL);
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+    }
+}

--- a/DataAccessLogic/src/main/java/Database/TermsRepository.java
+++ b/DataAccessLogic/src/main/java/Database/TermsRepository.java
@@ -1,5 +1,7 @@
 package Database;
+
 import DomainModels.Term;
+
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;


### PR DESCRIPTION
### The DB_User must now be given access to **Alter** and **Reference** tables

Created a new Class that can be used to drop and create FK_Constraint.

I found another approach of using `SET FOREIGN_KEY_CHECKS` This can only be used on a single connection and needed to be executed before and after each bulk insert into the contains table.

Running some tests to see the impact this has on speed.
